### PR TITLE
feat(work): implement work page and update site navigation

### DIFF
--- a/js/shared/site.js
+++ b/js/shared/site.js
@@ -124,8 +124,8 @@ function renderDesktopNav(pageType) {
     const links = [
       { label: 'Home', href: toHref(pageType, '') },
       { label: 'Blog', href: toHref(pageType, 'pages/blog/blog.html') },
-      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html') },
-      { label: 'Work', href: toHref(pageType, 'pages/work/work.html') }, */
+      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html') }, */
+      { label: 'Work', href: toHref(pageType, 'pages/work/work.html') },
       { label: 'About', href: toHref(pageType, 'pages/about/about.html') },
       { label: 'Contact', href: toHref(pageType, 'pages/contact/contact.html') },
     ];
@@ -153,8 +153,8 @@ function renderDesktopNav(pageType) {
       { label: 'Home', href: toHref(pageType, '') },
       { label: 'Blog', href: toHref(pageType, 'pages/blog/blog.html') },
       { label: 'Album', href: toHref(pageType, 'pages/album/album.html') },
-      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html') },
-      { label: 'Work', href: toHref(pageType, 'pages/work/work.html') }, */
+      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html') }, */
+      { label: 'Work', href: toHref(pageType, 'pages/work/work.html') },
       { label: 'Contact', href: toHref(pageType, 'pages/contact/contact.html') },
     ];
 
@@ -181,9 +181,37 @@ function renderDesktopNav(pageType) {
       { label: 'Home', href: toHref(pageType, '') },
       { label: 'Blog', href: toHref(pageType, 'pages/blog/blog.html') },
       { label: 'Album', href: toHref(pageType, 'pages/album/album.html') },
-      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html') },
-      { label: 'Work', href: toHref(pageType, 'pages/work/work.html') }, */
+      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html') }, */
+      { label: 'Work', href: toHref(pageType, 'pages/work/work.html') },
       { label: 'About', href: toHref(pageType, 'pages/about/about.html') },
+    ];
+
+    mount.innerHTML = `
+      <nav class="navigation" id="nav">
+        <div class="nav-cont">
+          <div class="nav-links" id="navLinks">
+            ${links.map((item) => `<a href="${item.href}" class="nav-link">${item.label}</a>`).join('')}
+          </div>
+
+          <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation">
+            <span></span>
+            <span></span>
+            <span></span>
+          </button>
+        </div>
+      </nav>
+    `;
+    return;
+  }
+
+  if (pageType === 'work') {
+    const links = [
+      { label: 'Home', href: toHref(pageType, '') },
+      { label: 'Blog', href: toHref(pageType, 'pages/blog/blog.html') },
+      { label: 'Album', href: toHref(pageType, 'pages/album/album.html') },
+      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html') }, */
+      { label: 'About', href: toHref(pageType, 'pages/about/about.html') },
+      { label: 'Contact', href: toHref(pageType, 'pages/contact/contact.html') },
     ];
 
     mount.innerHTML = `
@@ -211,8 +239,8 @@ function renderDesktopNav(pageType) {
   const links = [
     firstLink,
     { label: 'Album', href: toHref(pageType, 'pages/album/album.html') },
-    /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html') },
-    { label: 'Work', href: toHref(pageType, 'pages/work/work.html') }, */
+    /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html') }, */
+    { label: 'Work', href: toHref(pageType, 'pages/work/work.html') },
     { label: 'About', href: toHref(pageType, 'pages/about/about.html') },
     { label: 'Contact', href: toHref(pageType, 'pages/contact/contact.html') },
   ];
@@ -260,8 +288,8 @@ function renderMobileBottomNav(pageType) {
     const items = [
       { label: 'Home', href: toHref(pageType, ''), icon: iconHome() },
       { label: 'Blog', href: toHref(pageType, 'pages/blog/blog.html'), icon: iconBlog() },
-      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html'), icon: iconGallery() },
-      { label: 'Work', href: toHref(pageType, 'pages/work/work.html'), icon: iconWork() }, */
+      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html'), icon: iconGallery() }, */
+      { label: 'Work', href: toHref(pageType, 'pages/work/work.html'), icon: iconWork() },
       { label: 'About', href: toHref(pageType, 'pages/about/about.html'), icon: iconAbout() },
     ];
 
@@ -287,8 +315,8 @@ function renderMobileBottomNav(pageType) {
       { label: 'Home', href: toHref(pageType, ''), icon: iconHome() },
       { label: 'Blog', href: toHref(pageType, 'pages/blog/blog.html'), icon: iconBlog() },
       { label: 'Album', href: toHref(pageType, 'pages/album/album.html'), icon: iconAlbum() },
-      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html'), icon: iconGallery() },
-      { label: 'Work', href: toHref(pageType, 'pages/work/work.html'), icon: iconWork() }, */
+      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html'), icon: iconGallery() }, */
+      { label: 'Work', href: toHref(pageType, 'pages/work/work.html'), icon: iconWork() },
     ];
 
     mount.innerHTML = `
@@ -313,8 +341,34 @@ function renderMobileBottomNav(pageType) {
       { label: 'Home', href: toHref(pageType, ''), icon: iconHome() },
       { label: 'Blog', href: toHref(pageType, 'pages/blog/blog.html'), icon: iconBlog() },
       { label: 'Album', href: toHref(pageType, 'pages/album/album.html'), icon: iconAlbum() },
-      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html'), icon: iconGallery() },
-      { label: 'Work', href: toHref(pageType, 'pages/work/work.html'), icon: iconWork() }, */
+      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html'), icon: iconGallery() }, */
+      { label: 'Work', href: toHref(pageType, 'pages/work/work.html'), icon: iconWork() },
+      { label: 'About', href: toHref(pageType, 'pages/about/about.html'), icon: iconAbout() },
+    ];
+
+    mount.innerHTML = `
+      <nav class="mobile-bottom-nav" id="mobileBottomNav">
+        ${items
+          .map(
+            (item) => `
+              <a href="${item.href}" class="mobile-nav-item">
+                ${item.icon}
+                <span>${item.label}</span>
+              </a>
+            `
+          )
+          .join('')}
+      </nav>
+    `;
+    return;
+  }
+
+  if (pageType === 'work') {
+    const items = [
+      { label: 'Home', href: toHref(pageType, ''), icon: iconHome() },
+      { label: 'Blog', href: toHref(pageType, 'pages/blog/blog.html'), icon: iconBlog() },
+      { label: 'Album', href: toHref(pageType, 'pages/album/album.html'), icon: iconAlbum() },
+      /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html'), icon: iconGallery() }, */
       { label: 'About', href: toHref(pageType, 'pages/about/about.html'), icon: iconAbout() },
     ];
 
@@ -350,8 +404,8 @@ function renderMobileBottomNav(pageType) {
   const items = [
     first,
     { label: 'Album', href: toHref(pageType, 'pages/album/album.html'), icon: iconAlbum() },
-    /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html'), icon: iconGallery() },
-    { label: 'Work', href: toHref(pageType, 'pages/work/work.html'), icon: iconWork() }, */
+    /* { label: 'Gallery', href: toHref(pageType, 'pages/gallery/gallery.html'), icon: iconGallery() }, */
+    { label: 'Work', href: toHref(pageType, 'pages/work/work.html'), icon: iconWork() },
     { label: 'About', href: toHref(pageType, 'pages/about/about.html'), icon: iconAbout() },
   ];
 
@@ -586,5 +640,3 @@ function setHeroImage(imagePath) {
 }
 
 window.setHeroImage = setHeroImage;
-
-

--- a/pages/about/about.html
+++ b/pages/about/about.html
@@ -72,12 +72,14 @@
     </section>
   </main>
 
+  <!-- About values section kept here in comments for later reuse.
   <section class="about-values" aria-labelledby="aboutValuesTitle">
     <div class="about-values-shell">
       <h2 id="aboutValuesTitle" class="about-values-title"></h2>
       <div id="aboutValuesRows" class="about-values-rows"></div>
     </div>
   </section>
+  -->
 
   <section class="social">
     <div class="social-container">

--- a/pages/about/about.page.js
+++ b/pages/about/about.page.js
@@ -5,6 +5,7 @@ document.addEventListener("DOMContentLoaded", () => {
       description: "Personal developer portfolio of Mohammad Abdulmanan, bringing together web systems, interfaces, writing, and images.",
     },
     socialLabel: "WHERE MY WORLDS MEET",
+    /*
     valuesTitle: "What Matters to Me",
     values: [
       {
@@ -24,6 +25,7 @@ document.addEventListener("DOMContentLoaded", () => {
         description: "Precision matters, but it should still leave room for feeling.",
       },
     ],
+    */
     name: "Mohammad Abdulmanan",
     image: {
       src: "../../my-images/me_back.jpg",
@@ -50,8 +52,9 @@ document.addEventListener("DOMContentLoaded", () => {
   if (descriptionEl) descriptionEl.setAttribute("content", pageData.meta.description);
 
   setText("aboutSocialLabel", pageData.socialLabel);
-  setText("aboutValuesTitle", pageData.valuesTitle);
   setText("aboutName", pageData.name);
+  // About values section kept here in comments for later reuse.
+  // setText("aboutValuesTitle", pageData.valuesTitle);
 
   const portraitEl = document.getElementById("aboutPortrait");
   if (portraitEl) {
@@ -66,6 +69,8 @@ document.addEventListener("DOMContentLoaded", () => {
     copyEl.innerHTML = pageData.paragraphs.map((paragraph) => `<p>${paragraph}</p>`).join("");
   }
 
+  // About values section kept here in comments for later reuse.
+  /*
   const valuesEl = document.getElementById("aboutValuesRows");
   if (valuesEl) {
     valuesEl.innerHTML = pageData.values
@@ -79,4 +84,5 @@ document.addEventListener("DOMContentLoaded", () => {
       )
       .join("");
   }
+  */
 });

--- a/pages/album/album.page.js
+++ b/pages/album/album.page.js
@@ -1,7 +1,7 @@
 document.addEventListener("DOMContentLoaded", () => {
   const pageData = {
     meta: {
-      title: "Albums | Abdlmnn",
+      title: "Album | ABDLMNN",
       description:
         "Abdlmnn - Albums. Photo collections organized by theme and location.",
     },

--- a/pages/blog/blog.html
+++ b/pages/blog/blog.html
@@ -8,7 +8,7 @@
   <meta name="author" content="Mohammad Abdulmanan">
   <meta name="robots" content="index, follow">
   <meta id="blogMetaDescription" name="description" content="">
-  <title id="blogPageTitle"></title>
+  <title id="blogPageTitle">Blog | ABDLMNN</title>
 
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://abdlmnn.github.io/pages/blog/blog.html">
@@ -255,7 +255,7 @@
     </div>
   </footer>
 
-  <script src="blog.page.js"></script>
+  <script src="blog.page.js?v=1.1"></script>
   <script src="../../js/shared/site.js"></script>
 </body>
 

--- a/pages/blog/blog.page.js
+++ b/pages/blog/blog.page.js
@@ -82,6 +82,14 @@
     if (typeof imageData.src === "string") el.setAttribute("src", imageData.src);
     if (typeof imageData.alt === "string") el.setAttribute("alt", imageData.alt);
   };
+  blogData.meta.title = "Blog | ABDLMNN";
+  setText("blogPageTitle", blogData.meta.title);
+
+  const metaDescription = document.getElementById("blogMetaDescription");
+  if (metaDescription) {
+    metaDescription.setAttribute("content", blogData.meta.description);
+  }
+
   setText("blogHeroTitle", blogData.hero.title);
   setText("blogHeroSubtitle", blogData.hero.subtitle);
 

--- a/pages/blog/posts/first-post.html
+++ b/pages/blog/posts/first-post.html
@@ -8,7 +8,7 @@
   <meta name="author" content="Mohammad Abdulmanan">
   <meta name="robots" content="index, follow">
   <meta id="postMetaDescription" name="description" content="">
-  <title id="postTitle"></title>
+  <title id="postTitle">Why I Started This Blog | ABDLMNN</title>
 
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://abdlmnn.github.io/pages/blog/posts/first-post.html">
@@ -147,7 +147,7 @@
     </footer>
   </article>
 
-  <script src="post.page.js"></script>
+  <script src="post.page.js?v=1.1"></script>
   <script src="../../../js/shared/site.js"></script>
 </body>
 

--- a/pages/blog/posts/post.page.js
+++ b/pages/blog/posts/post.page.js
@@ -1,7 +1,7 @@
 (function () {
   const postData = {
     meta: {
-      title: "Built in Motion: Why I Started This Blog",
+      title: "Why I Started This Blog | ABDLMNN",
       description: "First blog post on my journey of sharing thoughts, lessons, and projects between Saudi Arabia and the Philippines.",
     },
     header: {

--- a/pages/blog/posts/second/index.html
+++ b/pages/blog/posts/second/index.html
@@ -8,7 +8,7 @@
   <meta name="author" content="Mohammad Abdulmanan">
   <meta name="robots" content="index, follow">
   <meta id="post2MetaDescription" name="description" content="">
-  <title id="post2PageTitle"></title>
+  <title id="post2PageTitle">What I Started Building | ABDLMNN</title>
   <link rel="icon" type="image/png" href="../../../../images/Me/font icon/1.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -103,7 +103,7 @@
 
   </article>
 
-  <script src="second-post.page.js"></script>
+  <script src="second-post.page.js?v=1.1"></script>
   <script src="../../../../js/shared/site.js"></script>
 </body>
 

--- a/pages/blog/posts/second/second-post.page.js
+++ b/pages/blog/posts/second/second-post.page.js
@@ -101,6 +101,7 @@
     el.innerHTML = value;
   };
 
+  postData.meta.title = "What I Started Building | ABDLMNN";
   setText("post2PageTitle", postData.meta.title);
 
   const metaDescription = document.getElementById("post2MetaDescription");

--- a/pages/contact/contact.css
+++ b/pages/contact/contact.css
@@ -324,13 +324,21 @@ a.contact-channel-value:hover {
   letter-spacing: 0.14em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: background 180ms ease, color 180ms ease, transform 180ms ease;
+  transition: opacity 180ms ease, transform 180ms ease;
 }
 
 .contact-submit:hover {
-  background: transparent;
-  color: var(--contact-ink);
+  opacity: 0.82;
   transform: translateY(-1px);
+}
+
+.contact-form-notice {
+  margin: 26px 0 0;
+  font-family: var(--font-sans);
+  font-size: 0.94rem;
+  font-weight: 300;
+  line-height: 1.6;
+  color: var(--contact-muted);
 }
 
 @media (max-width: 1024px) {

--- a/pages/contact/contact.html
+++ b/pages/contact/contact.html
@@ -121,6 +121,9 @@
               </div>
             </div>
 
+            <p id="contactFormNotice" class="contact-form-notice" role="status" aria-live="polite">
+              Form is not available yet. Please use email for now.
+            </p>
             <button class="contact-submit" type="submit">Submit Message</button>
           </form>
         </div>

--- a/pages/contact/contact.page.js
+++ b/pages/contact/contact.page.js
@@ -98,4 +98,11 @@ document.addEventListener("DOMContentLoaded", () => {
       })
       .join("");
   }
+
+  const contactForm = document.querySelector(".contact-form");
+  if (contactForm) {
+    contactForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+    });
+  }
 });

--- a/pages/work/work.css
+++ b/pages/work/work.css
@@ -1,0 +1,488 @@
+@import url('../../css/variable.css');
+
+:root {
+  --work-bg: #ffffff;
+  --work-ink: #191919;
+  --work-muted: #686868;
+  --work-faint: #8c8c8c;
+  --work-line: rgba(25, 25, 25, 0.1);
+  --work-line-strong: rgba(25, 25, 25, 0.22);
+  --work-shell: min(1120px, calc(100% - 56px));
+}
+
+body[data-page="work"] {
+  background: var(--work-bg);
+  color: var(--work-ink);
+}
+
+.work-page {
+  padding: calc(var(--nav-height) + 54px) 0 92px;
+}
+
+.work-shell {
+  width: var(--work-shell);
+  margin: 0 auto;
+}
+
+.work-kicker,
+.work-foundation-label,
+.work-chapter-number,
+.work-chapter-type,
+.work-project-detail-label {
+  margin: 0;
+  font-family: var(--font-syne);
+  font-size: 0.72rem;
+  font-weight: 400;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--work-faint);
+}
+
+.work-intro-title,
+.work-foundation-title,
+.work-experience-role,
+.work-project-title,
+.work-cta-title {
+  margin: 0;
+  font-family: var(--font-serif);
+  color: var(--work-ink);
+  letter-spacing: 0;
+}
+
+.work-intro-note,
+.work-foundation-value,
+.work-experience-company,
+.work-experience-period,
+.work-project-summary,
+.work-project-detail-text,
+.work-chapter-status,
+.work-cta-copy {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-weight: 300;
+  color: var(--work-muted);
+}
+
+.work-intro-header {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 32px 66px;
+}
+
+.work-intro-header > .work-kicker {
+  display: none;
+}
+
+.work-intro-topline {
+  grid-column: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 58px;
+  align-items: end;
+}
+
+.work-intro-title {
+  max-width: 760px;
+  font-size: clamp(1.5rem, 8vw, 2.5rem);
+  font-weight: 600;
+  line-height: 1.14;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.work-intro-note {
+  max-width: 320px;
+  font-size: 0.96rem;
+  line-height: 1.76;
+}
+
+.work-foundation,
+.work-chapters,
+.work-cta {
+  padding-top: 86px;
+}
+
+.work-foundation-grid {
+  display: grid;
+  gap: 46px;
+}
+
+.work-tools,
+.work-experience {
+  display: grid;
+  grid-template-columns: 158px minmax(0, 1fr);
+  gap: 26px 66px;
+  padding: 0;
+}
+
+.work-tools > .work-kicker,
+.work-experience > .work-kicker {
+  grid-column: 1;
+  grid-row: 1;
+  padding-top: 8px;
+}
+
+.work-tools-list,
+.work-experience-list {
+  grid-column: 2;
+  display: grid;
+}
+
+.work-experience-list {
+  gap: 34px;
+}
+
+.work-experience-item {
+  display: grid;
+  grid-template-columns: minmax(190px, 0.34fr) minmax(0, 1fr);
+  gap: 34px;
+}
+
+.work-experience-head {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+}
+
+.work-experience-role {
+  font-size: 1.45rem;
+  line-height: 1.08;
+}
+
+.work-experience-company,
+.work-experience-period {
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.work-experience-period {
+  color: var(--work-faint);
+}
+
+.work-experience-details {
+  display: grid;
+}
+
+.work-foundation-row {
+  display: grid;
+  grid-template-columns: 150px minmax(0, 1fr);
+  gap: 22px;
+  padding: 8px 0;
+}
+
+.work-foundation-row:first-child {
+  padding-top: 20px;
+}
+
+.work-foundation-value {
+  font-size: 0.96rem;
+  line-height: 1.64;
+}
+
+.work-chapters-list {
+  display: grid;
+  gap: 82px;
+}
+
+.work-view-all {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: max-content;
+  margin: 58px auto 0;
+  padding: 0 0 14px;
+  border: 0;
+  border-bottom: 1px solid rgba(25, 25, 25, 0.28);
+  background: transparent;
+  color: var(--work-ink);
+  font-family: var(--font-syne);
+  font-size: 0.78rem;
+  font-weight: 400;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color var(--transition-fast), transform var(--transition-fast);
+}
+
+.work-view-all:hover {
+  transform: translateY(-1px);
+}
+
+.work-view-all[hidden] {
+  display: none;
+}
+
+.work-chapter {
+  display: grid;
+  grid-template-columns: 158px minmax(0, 1fr);
+  gap: 24px 66px;
+  padding-top: 0;
+}
+
+.work-chapter-marker {
+  padding-top: 7px;
+}
+
+.work-chapter-number {
+  font-size: 1.9rem;
+  line-height: 1;
+  color: rgba(25, 25, 25, 0.34);
+}
+
+.work-chapter-main {
+  display: grid;
+  gap: 24px;
+}
+
+.work-chapter-header {
+  display: grid;
+  gap: 13px;
+  padding-bottom: 18px;
+}
+
+.work-chapter-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 10px 20px;
+}
+
+.work-chapter-status {
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.work-project-title {
+  font-size: 2.45rem;
+  line-height: 1.02;
+}
+
+.work-project-summary {
+  max-width: 680px;
+  font-size: 1rem;
+  line-height: 1.64;
+}
+
+.work-chapter-body {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(380px, 0.62fr);
+  gap: 56px;
+  padding-top: 26px;
+  border-top: 1px solid var(--work-line);
+}
+
+.work-project-details,
+.work-project-facts {
+  display: grid;
+}
+
+.work-project-detail,
+.work-project-fact {
+  display: grid;
+  grid-template-columns: 132px minmax(0, 1fr);
+  gap: 22px;
+  padding: 8px 0;
+}
+
+.work-project-facts {
+  padding-left: 26px;
+  border-left: 1px solid var(--work-line);
+}
+
+.work-project-detail-text {
+  font-size: 0.96rem;
+  line-height: 1.64;
+}
+
+.work-cta-block {
+  display: grid;
+  grid-template-columns: minmax(0, 0.78fr) minmax(260px, 0.38fr);
+  gap: 56px;
+  align-items: end;
+  padding: 42px 0 0;
+  border-top: 1px solid var(--work-line);
+}
+
+.work-cta-block > .work-kicker {
+  display: none;
+}
+
+.work-cta-title,
+.work-cta-copy,
+.work-cta-actions {
+  grid-column: auto;
+}
+
+.work-cta-title {
+  max-width: 760px;
+  font-size: 2.55rem;
+  line-height: 1.06;
+}
+
+.work-cta-copy {
+  grid-column: 1;
+  max-width: 620px;
+  margin-top: -28px;
+  font-size: 0.98rem;
+  line-height: 1.74;
+}
+
+.work-cta-actions {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-self: stretch;
+}
+
+.work-cta-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-width: 0;
+  padding: 15px 18px;
+  border: 1px solid rgba(25, 25, 25, 0.2);
+  font-family: var(--font-syne);
+  font-size: 0.76rem;
+  font-weight: 400;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--work-ink);
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+}
+
+.work-cta-link:first-child {
+  background: var(--work-ink);
+  color: #ffffff;
+}
+
+.work-cta-link:hover {
+  background: #f1f1f1;
+  color: var(--work-ink);
+  opacity: 1;
+  transform: translateY(-1px);
+}
+
+.work-cta-link:first-child:hover {
+  background: var(--work-ink);
+  color: #ffffff;
+  opacity: 0.82;
+  transform: translateY(-1px);
+}
+
+@media (max-width: 1024px) {
+  :root {
+    --work-shell: calc(100% - 48px);
+  }
+
+  .work-intro-topline,
+  .work-chapter-body {
+    grid-template-columns: 1fr;
+  }
+
+  .work-intro-note {
+    max-width: 620px;
+  }
+
+  .work-project-facts {
+    padding-left: 0;
+    border-left: 0;
+    border-top: 1px solid var(--work-line);
+    padding-top: 18px;
+  }
+
+  .work-cta-block {
+    grid-template-columns: 1fr;
+    align-items: start;
+    gap: 24px;
+  }
+
+  .work-cta-copy,
+  .work-cta-actions {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .work-cta-copy {
+    margin-top: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  :root {
+    --work-shell: calc(100% - 30px);
+  }
+
+  .work-page {
+    padding: 38px 0 88px;
+  }
+
+  .work-intro-header,
+  .work-tools,
+  .work-experience,
+  .work-chapter,
+  .work-cta-block {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .work-intro-header > .work-kicker,
+  .work-intro-topline,
+  .work-tools > .work-kicker,
+  .work-experience > .work-kicker,
+  .work-tools-list,
+  .work-experience-list,
+  .work-cta-block > .work-kicker,
+  .work-cta-title,
+  .work-cta-copy,
+  .work-cta-actions {
+    grid-column: 1;
+  }
+
+  .work-intro-title {
+    font-size: clamp(1.4rem, 8.5vw, 2.2rem);
+    line-height: 1.14;
+  }
+
+  .work-foundation,
+  .work-chapters,
+  .work-cta {
+    padding-top: 72px;
+  }
+
+  .work-cta-title {
+    font-size: 1.62rem;
+  }
+
+  .work-foundation-row,
+  .work-experience-item,
+  .work-project-detail,
+  .work-project-fact {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .work-experience-list {
+    gap: 42px;
+  }
+
+  .work-chapters-list {
+    gap: 62px;
+  }
+
+  .work-project-title {
+    font-size: 1.95rem;
+  }
+
+  .work-chapter-meta {
+    display: grid;
+  }
+
+  .work-cta-actions {
+    gap: 12px;
+  }
+}

--- a/pages/work/work.html
+++ b/pages/work/work.html
@@ -5,20 +5,106 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#ffffff">
-  <meta id="workMetaDescription" name="description" content="Work page is being prepared.">
-  <title id="workPageTitle">Work | Coming Soon</title>
-  <link rel="stylesheet" href="../blog/posts/post.css">
+  <meta name="author" content="Mohammad Abdulmanan">
+  <meta name="robots" content="index, follow">
+  <meta id="workMetaDescription" name="description" content="">
+  <title id="workPageTitle"></title>
+
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://abdlmnn.github.io/pages/work/work.html">
+  <meta property="og:title" content="Work | ABDLMNN">
+  <meta property="og:description"
+    content="Selected work by Mohammad Abdulmanan across real systems, mobile-connected experiences, and interface design.">
+  <meta property="og:image" content="https://abdlmnn.github.io/my-images/projects/pharmago/menu_dashboard_pharmacy.png">
+  <meta property="og:image:alt" content="PharmaGo pharmacy dashboard preview">
+  <meta property="og:site_name" content="ABDLMNN">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://abdlmnn.github.io/pages/work/work.html">
+  <meta name="twitter:title" content="Work | ABDLMNN">
+  <meta name="twitter:description"
+    content="Selected work by Mohammad Abdulmanan across real systems, mobile-connected experiences, and interface design.">
+  <meta name="twitter:image" content="https://abdlmnn.github.io/my-images/projects/pharmago/menu_dashboard_pharmacy.png">
+
+  <link rel="canonical" href="https://abdlmnn.github.io/pages/work/work.html">
+  <link rel="icon" type="image/svg+xml" href="../../images/Me/font icon/1.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600&family=Poppins:wght@300;400;500&display=swap"
+    rel="stylesheet">
+
+  <link rel="stylesheet" href="../index/index.css">
+  <link rel="stylesheet" href="./work.css?v=2.9">
 </head>
 
-<body data-page="placeholder">
-  <main class="placeholder-page">
-    <section class="placeholder-card">
-      <p class="placeholder-kicker">Coming Soon</p>
-      <h1 class="placeholder-title">Work Page In Progress</h1>
-      <p class="placeholder-copy">This page is under construction and will be updated with full content soon.</p>
-      <a class="placeholder-link" href="/">Go to Home</a>
+<body data-page="work">
+  <div id="siteNavMount"></div>
+  <div id="mobileNavMount"></div>
+  <div id="contactFabMount"></div>
+
+  <main class="work-page">
+    <section class="work-intro" aria-labelledby="workHeroTitle">
+      <div class="work-shell">
+        <div class="work-intro-header">
+          <p id="workHeroKicker" class="work-kicker"></p>
+          <div class="work-intro-topline">
+            <h1 id="workHeroTitle" class="work-intro-title"></h1>
+            <p id="workHeroLead" class="work-intro-note"></p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="work-foundation" aria-labelledby="workToolsTitle">
+      <div class="work-shell">
+        <div class="work-foundation-grid">
+          <section class="work-tools" aria-labelledby="workToolsTitle">
+            <p id="workToolsTitle" class="work-kicker">Tools I Use</p>
+            <div id="workToolsList" class="work-tools-list"></div>
+          </section>
+
+          <section class="work-experience" aria-labelledby="workExperienceTitle">
+            <p id="workExperienceTitle" class="work-kicker">Experience</p>
+            <div id="workExperienceList" class="work-experience-list"></div>
+          </section>
+        </div>
+      </div>
+    </section>
+
+    <section class="work-chapters" aria-label="Selected work">
+      <div class="work-shell">
+        <div id="workProjectsList" class="work-chapters-list"></div>
+        <!--
+        <button id="workViewAllProjects" class="work-view-all" type="button" hidden>View All Projects</button>
+        -->
+      </div>
+    </section>
+
+    <section class="work-cta" aria-labelledby="workCtaTitle">
+      <div class="work-shell">
+        <div class="work-cta-block">
+          <p id="workCtaKicker" class="work-kicker"></p>
+          <h2 id="workCtaTitle" class="work-cta-title"></h2>
+          <p id="workCtaCopy" class="work-cta-copy"></p>
+          <div class="work-cta-actions">
+            <a id="workCtaPrimary" class="work-cta-link" href="../contact/contact.html"></a>
+            <a id="workCtaSecondary" class="work-cta-link" href="../about/about.html"></a>
+          </div>
+        </div>
+      </div>
     </section>
   </main>
+
+  <footer class="footer">
+    <div class="footer-container">
+      <p class="footer-text">&copy; 2026 Mohammad Abdulmanan. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script src="../../js/shared/site.js?v=1.1"></script>
+  <script src="./work.page.js?v=2.1"></script>
 </body>
 
 </html>

--- a/pages/work/work.page.js
+++ b/pages/work/work.page.js
@@ -1,0 +1,359 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const pageData = {
+    meta: {
+      title: "Work | ABDLMNN",
+      description:
+        "Selected work by Mohammad Abdulmanan across web systems, mobile-connected experiences, and interface-driven problem solving.",
+    },
+    hero: {
+      kicker: "",
+      title: "Systems I have built.",
+      lead: "A concise record of what I worked on, what I contributed, and what each system was made to improve.",
+    },
+    tools: {
+      items: [
+        {
+          label: "Frontend",
+          value: "React, Next.js, TypeScript, JavaScript, Tailwind CSS",
+        },
+        {
+          label: "Backend",
+          value: "Django, Django REST Framework, PHP, PostgreSQL, MySQL",
+        },
+        {
+          label: "Mobile",
+          value: "React Native, Expo",
+        },
+        {
+          label: "DevOps & Tools",
+          value: "GitHub, GitLab, Figma, Docker, Ubuntu",
+        },
+      ],
+    },
+    experience: {
+      items: [
+        /*
+        {
+          role: "Next Experience",
+          company: "To be added",
+          period: "Upcoming",
+          details: [
+            {
+              label: "Focus",
+              value:
+                "A placeholder entry to preview how a newer experience will sit above older roles.",
+            },
+            {
+              label: "Note",
+              value:
+                "Replace this once you have another role, freelance work, collaboration, or project-based experience.",
+            },
+          ],
+        },
+        */
+        {
+          role: "Intern Web Developer",
+          company: "Iligan Light & Power, Inc.",
+          period: "Dec 2025 to Apr 2026",
+          details: [
+            {
+              label: "Built",
+              value:
+                "An HR management system for job postings, applications, and internship intake so the company could move away from slower manual processing.",
+            },
+            {
+              label: "Contributed",
+              value:
+                "Worked on backend structure and API development with Django, while also helping design the web interface with Next.js.",
+            },
+            {
+              label: "Collaboration",
+              value:
+                "GitLab workflow, code review, and backend leadership responsibilities.",
+            },
+            {
+              label: "Deployment",
+              value:
+                "Production exposure with proxy setup, Proxmox, and Ubuntu.",
+            },
+          ],
+        },
+        {
+          role: "Hello World",
+          company: "Wrote my first line of code",
+          period: "Aug 2022",
+          details: [
+            {
+              label: "Started",
+              value:
+                "The first small step into programming, curiosity, and building things with code.",
+            },
+          ],
+        },
+      ],
+    },
+    projects: [
+      {
+        slug: "sarig",
+        name: "Sarig",
+        type: "Logistics Super App / Delivery and Transport Platform",
+        status: "In Development",
+        summary:
+          "A local logistics Super App for Marawi, built for trusted delivery and transport.",
+        whatItSolved:
+          // "Marawi has limited organized delivery and ride-hailing options. Sarig creates a clearer flow for food, medicine, groceries, and transport.",
+          "Marawi lacks a unified digital system for everyday delivery and transport services. Sarig brings food, medicine, groceries, motorcycle taxi, and private car services into a clearer app-based flow.",
+        whatIDid:
+          "Designed the product direction, system architecture, user roles, service categories, frontend foundation, and geo-based delivery flow.",
+        contribution:
+          "Connected customers, merchants, riders, and admins through one model for delivery, transport, store discovery, and rider coordination.",
+        accomplished:
+          // "Built the core product foundation and MVP for food, grocery, pharmacy, motorcycle taxi, and private car services, with admin and merchant tools.",
+          "Built the backend foundation for advanced delivery services, covering food, grocery, and pharmacy flows with geo-based store discovery, distance handling, and rider coordination logic, alongside the early admin and merchant dashboard structure.",
+        role:
+          "Founder / Product Builder / Full-stack Developer",
+        stack:
+          "Next.js, React, TypeScript, Tailwind CSS, Django REST Framework, GeoDjango, PostgreSQL, PostGIS, Docker, Google Maps API",
+        platforms: "Web + Mobile",
+      },
+      {
+        slug: "ilpi-hr-management",
+        name: "HR Management System",
+        type: "Internship Project / Human Resources Platform",
+        status: "Internship Project",
+        summary:
+          "An HR system for Iligan Light & Power, Inc. built for job posts, applications, and internship intake.",
+        whatItSolved:
+          "Manual hiring workflows, scattered applicant records, and slower processing for recruitment and internship applications.",
+        whatIDid:
+          "Worked on backend structure and API development with Django while helping shape the web interface with Next.js.",
+        contribution:
+          "Helped create a clearer digital workflow for HR teams to manage job posts, applicants, and internship submissions.",
+        accomplished:
+          "Delivered core system foundations during my internship at Iligan Light & Power, Inc.",
+        role:
+          "Intern Web Developer",
+        stack:
+          "Django, Django REST Framework, Next.js, React, PostgreSQL",
+        platforms: "Web",
+      },
+      {
+        slug: "pharmago",
+        name: "PharmaGo",
+        type: "Capstone / Multi-Pharmacy On-Demand Medicine Platform",
+        status: "Completed Project",
+        summary:
+          "A centralized medicine ordering and delivery system for customers, pharmacies, riders, and admins in Iligan City.",
+        whatItSolved:
+          "Scattered pharmacy transactions, weak coordination, and unclear delivery flow.",
+        whatIDid:
+          "Planned the system structure, built the backend and frontend, designed user roles, and connected the core delivery flow.",
+        contribution:
+          "Turned a fragmented ordering process into one connected system with clearer operations.",
+        accomplished:
+          "Delivered a complete capstone platform across web and mobile with operational role coverage.",
+        role:
+          "Full-stack Developer / System Developer, Team Build",
+        stack:
+          "Django, Django REST Framework, ReactJS, React Native, PostgreSQL, Google Maps API",
+        platforms: "Web + Mobile",
+      },
+      /*
+      {
+        slug: "codbit",
+        name: "Codbit",
+        type: "Developer Tool / Productivity Platform",
+        status: "In Development",
+        summary:
+          "A coding-focused project built around making development work clearer, faster, and easier to organize.",
+        whatItSolved:
+          "Scattered development notes, project context, and workflow friction while building software.",
+        whatIDid:
+          "Worked on the product direction, interface flow, and core development experience.",
+        contribution:
+          "Created a more structured way to support coding work and keep project context close to the developer.",
+        accomplished:
+          "Built the foundation for a tool focused on practical development productivity.",
+        role:
+          "Product Builder / Full-stack Developer",
+        stack:
+          "JavaScript, TypeScript, React, Node.js",
+        platforms: "Web",
+      },
+      {
+        slug: "stuart-boutique",
+        name: "Stuart Boutique",
+        type: "Boutique Website / Online Storefront",
+        status: "Completed Project",
+        summary:
+          "A boutique-focused web project designed to present products, brand identity, and customer-facing information clearly.",
+        whatItSolved:
+          "Limited online visibility and the need for a clearer digital storefront for boutique customers.",
+        whatIDid:
+          "Built the website structure, page flow, visual presentation, and customer-facing interface.",
+        contribution:
+          "Helped turn the boutique presence into a cleaner and more accessible online experience.",
+        accomplished:
+          "Delivered a polished storefront foundation for showcasing boutique products and brand details.",
+        role:
+          "Web Developer / Designer",
+        stack:
+          "HTML, CSS, JavaScript",
+        platforms: "Web",
+      },
+      */
+    ],
+    cta: {
+      kicker: "",
+      title: "Have an idea that needs structure, clarity, and a real path forward?",
+      copy:
+        "I care about building things that are useful, understandable, and made with intention. If you are hiring, planning a project, or exploring a collaboration, I would be glad to talk.",
+      primaryLabel: "Start A Conversation",
+      secondaryLabel: "Learn More",
+    },
+  };
+
+  const setText = (id, value) => {
+    const el = document.getElementById(id);
+    if (el && typeof value === "string") {
+      el.textContent = value;
+    }
+  };
+
+  const titleEl = document.getElementById("workPageTitle");
+  if (titleEl) titleEl.textContent = pageData.meta.title;
+
+  const descEl = document.getElementById("workMetaDescription");
+  if (descEl) descEl.setAttribute("content", pageData.meta.description);
+
+  setText("workHeroKicker", pageData.hero.kicker);
+  setText("workHeroTitle", pageData.hero.title);
+  setText("workHeroLead", pageData.hero.lead);
+
+  const toolsListEl = document.getElementById("workToolsList");
+  if (toolsListEl) {
+    toolsListEl.innerHTML = pageData.tools.items
+      .map(
+        (item) => `
+          <article class="work-foundation-row">
+            <p class="work-foundation-label">${item.label}</p>
+            <p class="work-foundation-value">${item.value}</p>
+          </article>
+        `,
+      )
+      .join("");
+  }
+
+  const experienceListEl = document.getElementById("workExperienceList");
+  if (experienceListEl) {
+    experienceListEl.innerHTML = pageData.experience.items
+      .map(
+        (item) => `
+          <article class="work-experience-item">
+            <header class="work-experience-head">
+              <h3 class="work-experience-role">${item.role}</h3>
+              <p class="work-experience-company">${item.company}</p>
+              <p class="work-experience-period">${item.period}</p>
+            </header>
+            <div class="work-experience-details">
+              ${item.details
+                .map(
+                  (detail) => `
+                    <div class="work-foundation-row">
+                      <p class="work-foundation-label">${detail.label}</p>
+                      <p class="work-foundation-value">${detail.value}</p>
+                    </div>
+                  `,
+                )
+                .join("")}
+            </div>
+          </article>
+        `,
+      )
+      .join("");
+  }
+
+  setText("workCtaKicker", pageData.cta.kicker);
+  setText("workCtaTitle", pageData.cta.title);
+  setText("workCtaCopy", pageData.cta.copy);
+  setText("workCtaPrimary", pageData.cta.primaryLabel);
+  setText("workCtaSecondary", pageData.cta.secondaryLabel);
+
+  const projectLimit = 3;
+  const projectsListEl = document.getElementById("workProjectsList");
+  const viewAllProjectsBtn = document.getElementById("workViewAllProjects");
+  const renderProjects = (projects) => {
+    projectsListEl.innerHTML = projects
+      .map((project, index) => {
+        const projectNumber = String(index + 1).padStart(2, "0");
+        return `
+          <article id="project-${project.slug}" class="work-chapter">
+            <div class="work-chapter-marker">
+              <p class="work-chapter-number">${projectNumber}</p>
+            </div>
+
+            <div class="work-chapter-main">
+              <header class="work-chapter-header">
+                <div class="work-chapter-meta">
+                  <p class="work-chapter-type">${project.type}</p>
+                  <p class="work-chapter-status">${project.status}</p>
+                </div>
+                <h3 class="work-project-title">${project.name}</h3>
+                <p class="work-project-summary">${project.summary}</p>
+              </header>
+
+              <div class="work-chapter-body">
+                <div class="work-project-details">
+                  <div class="work-project-detail">
+                    <p class="work-project-detail-label">What it solved</p>
+                    <p class="work-project-detail-text">${project.whatItSolved}</p>
+                  </div>
+                  <div class="work-project-detail">
+                    <p class="work-project-detail-label">What I did</p>
+                    <p class="work-project-detail-text">${project.whatIDid}</p>
+                  </div>
+                  <div class="work-project-detail">
+                    <p class="work-project-detail-label">Contribution</p>
+                    <p class="work-project-detail-text">${project.contribution}</p>
+                  </div>
+                  <div class="work-project-detail">
+                    <p class="work-project-detail-label">Accomplished</p>
+                    <p class="work-project-detail-text">${project.accomplished}</p>
+                  </div>
+                </div>
+
+                <div class="work-project-facts">
+                  <div class="work-project-fact">
+                    <p class="work-project-detail-label">Role</p>
+                    <p class="work-project-detail-text">${project.role}</p>
+                  </div>
+                  <div class="work-project-fact">
+                    <p class="work-project-detail-label">Platform</p>
+                    <p class="work-project-detail-text">${project.platforms}</p>
+                  </div>
+                  <div class="work-project-fact">
+                    <p class="work-project-detail-label">Stack</p>
+                    <p class="work-project-detail-text">${project.stack}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </article>
+        `;
+      })
+      .join("");
+  };
+
+  if (projectsListEl) {
+    const hasMoreProjects = pageData.projects.length > projectLimit;
+    renderProjects(pageData.projects.slice(0, projectLimit));
+
+    if (viewAllProjectsBtn && hasMoreProjects) {
+      viewAllProjectsBtn.hidden = false;
+      viewAllProjectsBtn.addEventListener("click", () => {
+        renderProjects(pageData.projects);
+        viewAllProjectsBtn.hidden = true;
+      });
+    }
+  }
+});


### PR DESCRIPTION
Implement the new work page including professional experience, tools, and project showcases. Update the global navigation to include the work link and refine metadata/titles across the blog and about pages.

- Add `pages/work/` with HTML, CSS, and JS
- Update `js/shared/site.js` to include 'Work' in navigation
- Refactor blog post metadata and titles for consistency
- Update contact page with form notice and prevent default submission
- Clean up about page by commenting out unused values section