### PR TITLE
refactor(album): redesign prologue section and update layout styles

### DIFF
--- a/pages/album/album.css
+++ b/pages/album/album.css
@@ -6,14 +6,7 @@
   --album-text-muted: #999999;
   --album-border-lighter: #f0f0f0;
   --album-bg-cream: #f8f7f5;
-  --album-intro-image-right: -22%;
-  --album-intro-image-width: min(125%, 1024px);
-  --album-intro-image-height: 200%;
-  --album-intro-mobile-image-width: 1180px;
-  --album-intro-mobile-image-height: 125%;
-  --album-intro-mobile-image-left: 55%;
-  --album-intro-mobile-image-top: 50%;
-  --album-intro-tiny-image-width: 1120px;
+  --album-shell: min(1175px, calc(100% - 48px));
 }
 
 body {
@@ -23,7 +16,9 @@ body {
 }
 
 .albums-header {
-  padding: calc(var(--nav-height) + 60px) 20px 40px;
+  width: var(--album-shell);
+  margin: 0 auto;
+  padding: calc(var(--nav-height) + 60px) 20px 42px;
   text-align: center;
   background: var(--album-bg-white);
 }
@@ -40,81 +35,161 @@ body {
 
 .albums-subtitle {
   font-family: var(--font-sans);
-  font-size: 1rem;
+  font-size: 16px;
   font-weight: 300;
   color: var(--album-text-secondary);
-  letter-spacing: 0.05em;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
 }
 
 .albums-main {
   width: min(1160px, calc(100% - 48px));
   margin: 0 auto;
-  padding: 0 0 80px;
+  padding: 0 0 96px;
 }
 
 .prologue-section {
-  width: min(1175px, calc(100% - 48px));
-  margin: 0 auto 110px;
+  width: var(--album-shell);
+  margin: 0 auto 116px;
 }
 
 .prologue-media {
   position: relative;
-  min-height: clamp(560px, 72vh, 820px);
-  overflow: hidden;
-  background: #2a2724;
+  min-height: 0;
+  overflow: visible;
+  display: block;
+  padding-top: clamp(500px, 58vw, 680px);
+  background: transparent;
+}
+
+.prologue-media::before {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  left: 50%;
+  width: min(980px, calc(100% - 96px));
+  height: clamp(500px, 58vw, 680px);
+  background:
+    radial-gradient(circle at 50% 32%, rgba(255, 255, 255, 0.12), transparent 34%),
+    linear-gradient(145deg, #24211d, #10100f 72%);
+  transform: translateX(-50%);
+}
+
+.prologue-media::after {
+  content: none;
+  position: absolute;
+  z-index: 2;
+  top: calc(clamp(500px, 58vw, 680px) - 42px);
+  right: max(72px, calc((100% - min(980px, calc(100% - 96px))) / 2 + 28px));
+  color: rgba(255, 255, 255, 0.35);
+  font-family: var(--font-sans);
+  font-size: 0.58rem;
+  font-weight: 300;
+  letter-spacing: 0.26em;
+  line-height: 1.6;
+  text-transform: uppercase;
 }
 
 .prologue-image {
+  display: block;
   position: absolute;
-  top: 50%;
-  left: auto;
-  right: var(--album-intro-image-right);
-  width: var(--album-intro-image-width);
+  z-index: 1;
+  top: -4%;
+  left: 50%;
+  bottom: auto;
+  width: min(850px, 72vw);
   max-width: none;
-  height: var(--album-intro-image-height);
+  height: auto;
+  margin: 0;
+  /* padding-top: clamp(28px, 4vw, 48px); */
   object-fit: contain;
-  filter: brightness(0.92) saturate(0.86);
-  transform: translateY(-50%);
+  object-position: center bottom;
+  filter: brightness(0.98) saturate(0.92) drop-shadow(0 34px 32px rgba(0, 0, 0, 0.42));
+  transform: translateX(-45%);
+  transform-origin: center bottom;
 }
 
 .prologue-scrim {
   position: absolute;
-  inset: 0;
+  z-index: 2;
+  top: 0;
+  left: 50%;
+  width: min(980px, calc(100% - 96px));
+  height: clamp(500px, 58vw, 680px);
   background:
-    /* radial-gradient(circle at 18% 78%, rgba(0, 0, 0, 0.38) 0%, rgba(0, 0, 0, 0.18) 36%, rgba(0, 0, 0, 0.03) 70%),
-    linear-gradient(90deg, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.12) 48%, rgba(255, 255, 255, 0.04) 100%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(0, 0, 0, 0.28) 100%); */
-
-    radial-gradient(circle at 18% 78%, rgba(0, 0, 0, 0.48) 0%, rgba(0, 0, 0, 0.24) 34%, rgba(0, 0, 0, 0.04) 68%),
-    linear-gradient(90deg, rgba(0, 0, 0, 0.34) 0%, rgba(0, 0, 0, 0.16) 46%, rgba(0, 0, 0, 0.02) 100%),
-    linear-gradient(180deg, rgba(0, 0, 0, 0.04) 0%, rgba(0, 0, 0, 0.34) 100%);
+    linear-gradient(90deg, rgba(20, 19, 18, 0.26), rgba(20, 19, 18, 0.02) 46%, rgba(20, 19, 18, 0.24)),
+    linear-gradient(180deg, rgba(20, 19, 18, 0.02), rgba(20, 19, 18, 0.22));
+  pointer-events: none;
+  transform: translateX(-50%);
 }
 
 .prologue-container {
   position: relative;
-  z-index: 1;
-  min-height: inherit;
-  display: flex;
-  align-items: flex-end;
-  justify-content: flex-start;
-  padding: clamp(56px, 7vw, 76px);
+  z-index: 3;
+  width: min(760px, calc(100% - 120px));
+  margin: -270px auto 0;
+  padding: clamp(38px, 5vw, 62px) clamp(34px, 5vw, 62px);
+  background: #f6f4ee;
+  color: var(--album-text-primary);
+  box-shadow: 0 34px 42px rgba(20, 19, 18, 0.08);
 }
 
 .prologue-text {
   font-family: var(--font-serif);
-  font-size: clamp(1.05rem, 1.65vw, 1.32rem);
-  line-height: 1.72;
-  color: var(--album-border-lighter);
+  font-size: clamp(0.95rem, 1.28vw, 1.08rem);
+  line-height: 1.9;
+  color: var(--album-text-primary);
   font-style: italic;
   font-weight: 400;
   max-width: 590px;
   margin: 0;
   letter-spacing: 0.01em;
-  text-shadow: 0 2px 18px rgba(0, 0, 0, 0.42);
+  text-shadow: none;
+}
+
+.prologue-text span {
+  display: block;
+}
+
+.prologue-text span + span {
+  margin-top: clamp(18px, 2.8vw, 30px);
+}
+
+.prologue-lead {
+  font-size: clamp(1.18rem, 1.9vw, 1.58rem);
+  line-height: 1.35;
+}
+
+.prologue-closing {
+  max-width: none;
 }
 
 .prologue-text::before {
-  content: none;
+  content: "field note / 001";
+  display: block;
+  margin-bottom: clamp(18px, 3vw, 30px);
+  font-family: var(--font-sans);
+  font-size: 0.62rem;
+  font-style: normal;
+  font-weight: 300;
+  letter-spacing: 0.28em;
+  line-height: 1.6;
+  text-transform: uppercase;
+  color: var(--album-text-muted);
+}
+
+.prologue-text::after {
+  content: "if (silence) capture();";
+  display: block;
+  margin-top: clamp(20px, 3vw, 34px);
+  font-family: var(--font-sans);
+  font-size: 0.62rem;
+  font-style: normal;
+  font-weight: 300;
+  letter-spacing: 0.18em;
+  line-height: 1.7;
+  color: var(--album-text-secondary);
 }
 
 .masonry-gallery {
@@ -133,6 +208,17 @@ body {
   height: auto;
   aspect-ratio: auto;
   contain: layout paint style;
+}
+
+.gallery-item::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0;
+  height: 38%;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.42));
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
 }
 
 .gallery-item.layout-one {
@@ -195,11 +281,11 @@ body {
   position: absolute;
   top: 0;
   left: 20%;
-  transform: translateX(-50%);
   width: 90px;
   height: 100%;
   background: rgba(255, 255, 255, 0.95);
   z-index: 1;
+  transform: translateX(-50%) scaleY(0);
   transform-origin: top center;
   transition: transform 0.3s ease;
   display: flex;
@@ -325,25 +411,29 @@ body {
 }
 
 @media (max-width: 1024px) {
-  .prologue-image {
-    top: var(--album-intro-mobile-image-top);
-    left: var(--album-intro-mobile-image-left);
-    right: auto;
-    width: var(--album-intro-mobile-image-width);
-    max-width: none;
-    height: var(--album-intro-mobile-image-height);
-    transform: translate(-50%, -50%);
+  .prologue-media {
+    min-height: 0;
+    padding-top: clamp(480px, 66vw, 640px);
   }
 
-  /* .prologue-scrim {
-    background:
-      linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0%, rgba(0, 0, 0, 0.44) 100%),
-      radial-gradient(circle at 50% 42%, rgba(0, 0, 0, 0.02) 0%, rgba(0, 0, 0, 0.18) 72%);
-  } */
+  .prologue-media::before,
+  .prologue-scrim {
+    width: min(900px, calc(100% - 72px));
+    height: clamp(480px, 66vw, 640px);
+  }
+
+  .prologue-image {
+    top: -4%;
+    left: 50%;
+    bottom: auto;
+    width: min(780px, 78vw);
+    padding-top: 0;
+    transform: translateX(-45%);
+  }
 
   .prologue-container {
-    align-items: flex-end;
-    justify-content: flex-start;
+    width: min(720px, calc(100% - 96px));
+    margin: -250px auto 0;
     text-align: left;
   }
 
@@ -390,59 +480,60 @@ body {
 
 @media (max-width: 768px) {
   .albums-header {
-    padding: 24px 20px 20px;
+    padding: 26px 20px 28px;
+  }
+
+  .albums-subtitle {
+    font-size: 0.72rem;
+    letter-spacing: 0.2em;
   }
 
   .prologue-section {
-    width: calc(100% - 24px);
-    margin-bottom: 64px;
+    width: var(--album-shell);
+    margin-bottom: 102px;
+    overflow-x: clip;
   }
 
   .prologue-media {
-    min-height: 620px;
+    min-height: 0;
+    padding-top: clamp(455px, 92vw, 590px);
   }
 
-  /* .prologue-scrim {
-    background:
-      linear-gradient(180deg, rgba(0, 0, 0, 0.08) 0%, rgba(0, 0, 0, 0.58) 100%),
-      radial-gradient(circle at 50% 85%, rgba(0, 0, 0, 0.42) 0%, rgba(0, 0, 0, 0.12) 62%, rgba(0, 0, 0, 0.02) 100%);
-  } */
+  .prologue-media::before,
+  .prologue-scrim {
+    width: calc(100% - 32px);
+    height: clamp(455px, 92vw, 590px);
+  }
 
   .prologue-image {
-    top: var(--album-intro-mobile-image-top);
-    left: var(--album-intro-mobile-image-left);
-    right: auto;
-    width: var(--album-intro-mobile-image-width);
-    max-width: none;
-    height: var(--album-intro-mobile-image-height);
-    transform: translate(-50%, -50%);
+    top: -4%;
+    left: 50%;
+    bottom: auto;
+    width: clamp(560px, 106vw, 700px);
+    padding-top: 0;
+    transform: translateX(-45%);
   }
 
   .prologue-container {
-    align-items: flex-end;
-    justify-content: center;
-    padding: 34px 24px;
+    width: calc(100% - 40px);
+    margin: -228px auto 0;
+    padding: clamp(32px, 5vw, 44px) clamp(22px, 4.5vw, 32px);
     text-align: left;
+    box-shadow: 0 34px 42px rgba(20, 19, 18, 0.08);
   }
 
   .prologue-text {
-    color: #fff;
-    font-size: 1rem;
-    line-height: 1.75;
-    max-width: 92%;
-    margin: 0 auto;
+    color: var(--album-text-primary);
+    font-size: clamp(0.92rem, 1.8vw, 1rem);
+    line-height: 1.86;
+    max-width: 590px;
+    margin: 0;
     padding: 0;
-    background: none;
-    border: 0;
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    text-shadow:
-      0 2px 10px rgba(0, 0, 0, 0.58),
-      0 0 2px rgba(0, 0, 0, 0.45);
+    text-shadow: none;
   }
 
   .albums-main {
-    width: min(640px, calc(100% - 24px));
+    width: min(640px, calc(100% - 32px));
     padding: 0 0 80px;
   }
 
@@ -502,55 +593,99 @@ body {
   .gallery-item:not(:hover) .gallery-item-overlay,
   .gallery-item:hover .gallery-item-overlay {
     left: 16px;
-    bottom: 12px;
+    bottom: 16px;
     top: auto;
     width: auto;
     height: auto;
     transform: none;
-    background: linear-gradient(180deg, rgba(12, 12, 12, 0.866), rgba(12, 12, 12, 0.667));
-    border: 1px solid rgba(255, 255, 255, 0.132);
-    border-radius: 8px;
-    padding: 12px 8px;
-    min-height: 96px;
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.324);
-    backdrop-filter: blur(2px);
-    -webkit-backdrop-filter: blur(4px);
+    background: rgba(246, 244, 238, 0.92);
+    border: 0;
+    border-radius: 0;
+    padding: 10px 12px 9px;
+    min-height: 0;
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    opacity: 1;
   }
 
   .gallery-item-text {
-    writing-mode: vertical-rl;
+    writing-mode: horizontal-tb;
     text-orientation: mixed;
-    transform: rotate(180deg);
-    letter-spacing: 0.05em;
-    color: #fff;
-    font-size: 0.85rem;
-    font-weight: 600;
-    line-height: 1;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+    transform: none;
+    letter-spacing: 0.14em;
+    color: var(--album-text-primary);
+    font-family: var(--font-serif);
+    font-size: 0.76rem;
+    font-style: italic;
+    font-weight: 400;
+    line-height: 1.35;
+    text-shadow: none;
     opacity: 1;
     transition: none;
     text-transform: uppercase;
   }
+
 }
 
 @media (max-width: 480px) {
   .prologue-section {
-    width: calc(100% - 18px);
+    width: var(--album-shell);
+    margin-bottom: 108px;
+    overflow-x: clip;
   }
 
   .prologue-media {
-    min-height: 560px;
+    min-height: 0;
+    padding-top: clamp(455px, 116vw, 570px);
+  }
+
+  .prologue-scrim,
+  .prologue-media::before {
+    /* width: calc(100% - 24px); */
+    width: 100%;
+    height: clamp(455px, 116vw, 570px);
+  }
+
+  .prologue-image {
+    top: -4%;
+    left: 50%;
+    bottom: auto;
+    width: clamp(520px, 132vw, 620px);
+    height: auto;
+    padding-top: 0;
+    transform: translateX(-45%);
   }
 
   .prologue-container {
-    padding: 28px 18px;
+    width: calc(100% - 40px);
+    margin-top: -236px;
+    padding: 32px 22px;
+    box-shadow: 0 34px 42px rgba(20, 19, 18, 0.08);
   }
 
   .prologue-text {
-    max-width: 95%;
-    font-size: 0.95rem;
-    line-height: 1.72;
+    max-width: 590px;
+    font-size: 0.94rem;
+    line-height: 1.88;
     padding: 0;
+  }
+
+  .prologue-lead {
+    font-size: 1.12rem;
+    line-height: 1.35;
+  }
+
+  .prologue-text::before {
+    margin-bottom: 15px;
+    font-size: 0.55rem;
+    letter-spacing: 0.2em;
+  }
+
+  .prologue-text::after {
+    margin-top: 18px;
+    font-size: 0.55rem;
+    letter-spacing: 0.14em;
   }
 
   .albums-title {
@@ -581,12 +716,6 @@ body {
 
   .gallery-item.layout-three {
     aspect-ratio: 3 / 5;
-  }
-}
-
-@media (max-width: 468px) {
-  .prologue-image {
-    width: var(--album-intro-tiny-image-width);
   }
 }
 

--- a/pages/album/album.page.js
+++ b/pages/album/album.page.js
@@ -11,7 +11,8 @@ document.addEventListener("DOMContentLoaded", () => {
       src: "../../my-images/me_scrapbook.svg",
       alt: "Mohammad Abdulmanan holding a camera while taking photos",
     },
-    prologue: "I live in two languages.<br><br>The world is often framed as a binary: a sequence of logical operations or a collection of stories. As a developer, I build the systems; as a writer, I explore the souls within them.<br><br>But there is a wordless reality that exists between the code and the page—a space that doesn't care about brackets or grammar. These images are from that space. They are the moments where I stopped trying to solve the world or describe it, and simply stood still within it.<br><br>This is the light that spoke when I finally ran out of things&nbsp;to&nbsp;say.",
+    prologue:
+      '<span class="prologue-lead">I live in two languages.</span><span>The world is often framed as a binary: a sequence of logical operations or a collection of stories. As a developer, I build the systems; as a writer, I explore the souls within them.</span><span>But there is a wordless reality that exists between the code and the page, a space that does not care about brackets or grammar. These images are from that space. They are the moments where I stopped trying to solve the world or describe it, and simply stood still within it.</span><span class="prologue-closing">This is the light that spoke when I finally ran out of&nbsp;things&nbsp;to&nbsp;say.</span>',
     items: [
       {
         src: "../../images/KSA/1000027400 (2).jpg",
@@ -108,11 +109,10 @@ document.addEventListener("DOMContentLoaded", () => {
   };
 
   gallery.innerHTML = pageData.items
-    .map(
-      (item, index) => {
-        const size = getLayoutSize(item);
-        const isPriority = index < 6;
-        return `
+    .map((item, index) => {
+      const size = getLayoutSize(item);
+      const isPriority = index < 6;
+      return `
       <article class="gallery-item ${getLayoutClass(item)}">
         <img
           src="${item.src}"
@@ -128,7 +128,6 @@ document.addEventListener("DOMContentLoaded", () => {
         </div>
       </article>
     `;
-      },
-    )
+    })
     .join("");
 });


### PR DESCRIPTION
Refactor the album page styling and structure to implement a new design for the prologue section. This includes:

- Introducing `--album-shell` for consistent layout width.
- Redesigning `.prologue-media` with pseudo-elements for background gradients and decorative text.
- Updating `.prologue-image` positioning and filtering for a more integrated look.
- Updating the prologue text structure in `album.page.js` to support new typography styles via spans.
- Cleaning up unused CSS variables and simplifying the gallery item mapping logic.